### PR TITLE
Add monthly callback for PDF generation

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -1,0 +1,57 @@
+name: Monthly Resume Release
+
+on:
+  schedule:
+    # Run on the 1st of every month at 9:00 AM UTC
+    - cron: '0 9 1 * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up LaTeX
+        uses: dante-ev/latex-action@v2
+        with:
+          root_file: main.tex
+          
+      - name: Check PDF output
+        run: |
+          if [ ! -f main.pdf ]; then
+            echo "PDF not generated!" && exit 1
+          fi
+          
+      - name: Prepare release files
+        run: |
+          # Rename PDF with timestamp
+          TIMESTAMP=$(date +"%Y-%m")
+          mv main.pdf "resume-${TIMESTAMP}.pdf"
+          echo "RELEASE_FILE=resume-${TIMESTAMP}.pdf" >> $GITHUB_ENV
+          echo "RELEASE_TAG=v${TIMESTAMP}" >> $GITHUB_ENV
+          echo "RELEASE_TITLE=Resume Release ${TIMESTAMP}" >> $GITHUB_ENV
+          
+      - name: Create Release with PDF
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_DATE=$(date +"%B %d, %Y")
+          gh release create "${{ env.RELEASE_TAG }}" \
+            "${{ env.RELEASE_FILE }}" \
+            --title "${{ env.RELEASE_TITLE }}" \
+            --notes "📄 **Monthly Resume Release**
+
+          This is an automatically generated monthly release of the resume PDF.
+
+          **Generated on:** ${CURRENT_DATE}
+          **Build ID:** ${{ github.run_id }}
+
+          ### What's included:
+          - 📋 Latest resume in PDF format
+          - 🔄 Auto-generated from LaTeX source
+
+          ---
+          *This release was automatically created by GitHub Actions*"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ This repository contains the LaTeX source for the resume of Abdul Aziz Bin Abdul
   - PRs are automatically checked for successful LaTeX compilation.
   - On successful build, the resume PDF is generated and the README.md is updated with the latest PDF.
 
+## Monthly Releases
+This repository automatically creates monthly releases with the latest resume PDF:
+- **Schedule:** Automatically triggered on the 1st of every month at 9:00 AM UTC
+- **Manual Trigger:** Can be manually triggered via GitHub Actions
+- **Release Content:** Each release includes a timestamped PDF file (`resume-YYYY-MM.pdf`)
+- **Access:** All releases are available in the [Releases](../../releases) section
+
 ## License
 This repository and its contents are licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). See [LICENSE](LICENSE) for details.
 


### PR DESCRIPTION
Add a monthly scheduled GitHub Actions workflow to automatically generate and release the latest resume PDF.