### PR TITLE
Fix latex resume generation

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -1,16 +1,20 @@
-name: Build and Deploy LaTeX Resume
+name: Build and Release LaTeX Resume
 
 on:
   pull_request:
     branches: [ main ]
   push:
     branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up LaTeX
         uses: dante-ev/latex-action@v2
         with:
@@ -21,32 +25,41 @@ jobs:
             echo "PDF not generated!" && exit 1
           fi
       - name: Upload PDF artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: resume-pdf
           path: main.pdf
+          if-no-files-found: error
 
-  deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  release:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up LaTeX
-        uses: dante-ev/latex-action@v2
+      - name: Download PDF artifact
+        uses: actions/download-artifact@v4
         with:
-          root_file: main.tex
-      - name: Check PDF output
+          name: resume-pdf
+          path: dist
+      - name: Prepare release asset
         run: |
-          if [ ! -f main.pdf ]; then
-            echo "PDF not generated!" && exit 1
-          fi
-      - name: Commit and push PDF and update README
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          mv main.pdf resume.pdf
-          sed -i '/<!-- The PDF will be embedded here by the CI\/CD workflow. -->/a \\n[Download the latest resume (PDF)](./resume.pdf)\\n' README.md
-          git add resume.pdf README.md
-          git commit -m "Update resume PDF and README.md [auto]" || echo "No changes to commit"
-          git push 
+          TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
+          mv dist/main.pdf "dist/resume-${TIMESTAMP}.pdf"
+          echo "ASSET=dist/resume-${TIMESTAMP}.pdf" >> $GITHUB_ENV
+          echo "REL_TAG=build-${{ github.run_id }}" >> $GITHUB_ENV
+          echo "REL_NAME=Automated Resume Build ${TIMESTAMP}" >> $GITHUB_ENV
+      - name: Create prerelease with PDF
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.REL_TAG }}
+          name: ${{ env.REL_NAME }}
+          body: |
+            Automated build from commit ${{ github.sha }}.
+
+            - Branch: ${{ github.ref_name }}
+            - Run ID: ${{ github.run_id }}
+          prerelease: true
+          artifacts: ${{ env.ASSET }}
+          makeLatest: false
+          allowUpdates: true 

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -6,11 +6,12 @@ on:
     - cron: '0 9 1 * *'
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
       
@@ -31,27 +32,30 @@ jobs:
           TIMESTAMP=$(date +"%Y-%m")
           mv main.pdf "resume-${TIMESTAMP}.pdf"
           echo "RELEASE_FILE=resume-${TIMESTAMP}.pdf" >> $GITHUB_ENV
-          echo "RELEASE_TAG=v${TIMESTAMP}" >> $GITHUB_ENV
-          echo "RELEASE_TITLE=Resume Release ${TIMESTAMP}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=monthly-v${TIMESTAMP}" >> $GITHUB_ENV
+          echo "RELEASE_TITLE=Monthly Resume Release ${TIMESTAMP}" >> $GITHUB_ENV
+          echo "CURRENT_DATE=$(date +"%B %d, %Y")" >> $GITHUB_ENV
           
-      - name: Create Release with PDF
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          CURRENT_DATE=$(date +"%B %d, %Y")
-          gh release create "${{ env.RELEASE_TAG }}" \
-            "${{ env.RELEASE_FILE }}" \
-            --title "${{ env.RELEASE_TITLE }}" \
-            --notes "📄 **Monthly Resume Release**
+      - name: Create/Update Monthly Release with PDF
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_TITLE }}
+          body: |
+            📄 **Monthly Resume Release**
 
-          This is an automatically generated monthly release of the resume PDF.
+            This is an automatically generated monthly release of the resume PDF.
 
-          **Generated on:** ${CURRENT_DATE}
-          **Build ID:** ${{ github.run_id }}
+            **Generated on:** ${{ env.CURRENT_DATE }}
+            **Build ID:** ${{ github.run_id }}
 
-          ### What's included:
-          - 📋 Latest resume in PDF format
-          - 🔄 Auto-generated from LaTeX source
+            ### What's included:
+            - 📋 Latest resume in PDF format
+            - 🔄 Auto-generated from LaTeX source
 
-          ---
-          *This release was automatically created by GitHub Actions*"
+            ---
+            *This release was automatically created by GitHub Actions*
+          artifacts: ${{ env.RELEASE_FILE }}
+          makeLatest: true
+          allowUpdates: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/xu-cheng/latexmk:debian
+WORKDIR /work
+COPY . /work
+RUN latexmk -pdf -interaction=nonstopmode -halt-on-error main.tex && ls -lah main.pdf

--- a/main.tex
+++ b/main.tex
@@ -165,10 +165,9 @@
 \vspace{-6mm}
 
 \begin{center}
-    \small{
- 	\href{https://wa.me/\phoneNumber}{+\phonenumber[foreign
-]{\phoneNumber}} | 
-	\href{mailto:jazarie2@gmail.com}{jazarie2@gmail.com} |
+        \small{
+  	\href{https://wa.me/\phoneNumber}{+\phonenumber[foreign]{\phoneNumber}} | 
+ 	\href{mailto:jazarie2@gmail.com}{jazarie2@gmail.com} |
 	
 %    |
 %    \href{https://www.yourwebsite.com/}{yourwebsite.com}


### PR DESCRIPTION
Fix GitHub Actions workflows to reliably build LaTeX PDF and publish it as a GitHub Release on push and monthly triggers.

The previous CI/CD setup was failing to generate and release the PDF. This PR updates both `latex.yml` and `monthly-release.yml` to use `ncipollo/release-action@v1` for more robust release creation, ensuring the PDF is consistently available in the repository's Releases page.

---
<a href="https://cursor.com/background-agent?bcId=bc-81980fcc-17da-4edd-a2b2-4f835fe52b5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81980fcc-17da-4edd-a2b2-4f835fe52b5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

